### PR TITLE
Testing and documentation updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: false
+language: perl
+perl:
+   - 'blead'
+   - '5.22'
+   - '5.20'
+   - '5.18'
+   - '5.16'
+   - '5.14'
+   - '5.12'
+   - '5.10'
+   - '5.8'
+matrix:
+   allow_failures:
+      - perl: 'blead'
+      - perl: '5.8'
+   fast_finish: true
+before_install:
+   - git config --global user.name "TravisCI"
+   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
+install:
+   - cpanm --quiet --notest --skip-satisfied Dist::Zilla
+   - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
+   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
+script:
+   - dzil smoke --release --author

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: perl
 perl:
    - 'blead'
+   - '5.22'
    - '5.20'
    - '5.18'
    - '5.16'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: perl
 perl:
    - 'blead'
-   - '5.22'
    - '5.20'
    - '5.18'
    - '5.16'
@@ -21,6 +20,6 @@ before_install:
 install:
    - cpanm --quiet --notest --skip-satisfied Dist::Zilla
    - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
-   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
+   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose --notest"
 script:
    - dzil smoke --release --author

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-Data::Debug
-===========
-
-A debug tool used internally by Bluehost to easily determine the content of perl data structures.
-This was originally part of CGI::EX, but was found to be independantly beneficial. 

--- a/README.pod
+++ b/README.pod
@@ -1,8 +1,14 @@
 =pod
 
+=encoding UTF-8
+
 =head1 NAME
 
-Data::Debug - allows for basic data dumping and introspection.
+Data::Debug
+
+=head1 VERSION
+
+version 0.03
 
 =head1 SYNOPSIS
 
@@ -47,6 +53,10 @@ See also L<Data::Dumper>.
 
 Setting any of the Data::Dumper globals will alter the output.
 
+=head1 NAME
+
+Data::Debug - allows for basic data dumping and introspection.
+
 =head1 SUBROUTINES
 
 =over 4
@@ -90,5 +100,16 @@ This does require at least perl 5.8.0's Carp.
 
 Originally this was borrowed from CGI::Ex (written by Paul Seamons).  It
 has since had many customizations and optimizations by various people.
+
+=head1 AUTHOR
+
+[ 'Paul Seamons <paul@seamons.com>',  'Russel Fisher <geistberg@gmail.com>' ]
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2014 by Paul Seamons.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
 
 =cut

--- a/README.pod
+++ b/README.pod
@@ -1,0 +1,94 @@
+=pod
+
+=head1 NAME
+
+Data::Debug - allows for basic data dumping and introspection.
+
+=head1 SYNOPSIS
+
+  use Data::Debug; # auto imports debug, debug_warn
+  use Data::Debug qw(debug debug_text caller_trace);
+
+  my $hash = {
+      foo => ['a', 'b', 'Foo','a', 'b', 'Foo','a', 'b', 'Foo','a'],
+  };
+
+  debug $hash; # or debug_warn $hash;
+
+  debug;
+
+  debug "hi";
+
+  debug $hash, "hi", $hash;
+
+  debug \@INC; # print to STDOUT, or format for web if $ENV{REQUEST_METHOD}
+
+  debug_warn \@INC;  # same as debug but to STDOUT
+
+  print FOO debug_text \@INC; # same as debug but return dump
+
+  # ALSO #
+
+  use Data::Debug qw(debug);
+
+  debug; # same as debug
+
+=head1 DESCRIPTION
+
+Uses the base Data::Dumper of the distribution and gives it nicer formatting - and
+allows for calling just about anytime during execution.
+
+Calling Data::Debug::set_deparse() will allow for dumped output of subroutines
+if available.
+
+   perl -e 'use Data::Debug;  debug "foo", [1..10];'
+
+See also L<Data::Dumper>.
+
+Setting any of the Data::Dumper globals will alter the output.
+
+=head1 SUBROUTINES
+
+=over 4
+
+=item C<debug>
+
+Prints out pretty output to STDOUT.  Formatted for the web if on the web.
+
+It also returns the items called for it so that it can be used inline.
+
+   my $foo = debug [2,3]; # foo will contain [2,3]
+
+=item C<debug_warn>
+
+Prints to STDERR.
+
+=item C<debug_text>
+
+Return the text as a scalar.
+
+=item C<debug_plain>
+
+Return a plainer string as a scalar.  This basically just avoids the attempt to
+get variable names and line numbers and such.
+
+If passed multiple values, each value is joined by a newline.  This has the
+effect of placing an empty line between each one since each dump ends in a
+newline already.
+
+If called in void context, it displays the result on the default filehandle
+(usually STDOUT).
+
+=item C<caller_trace>
+
+Caller trace returned as an arrayref.  Suitable for use like "debug caller_trace".
+This does require at least perl 5.8.0's Carp.
+
+=back
+
+=head1 AUTHORS
+
+Originally this was borrowed from CGI::Ex (written by Paul Seamons).  It
+has since had many customizations and optimizations by various people.
+
+=cut

--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,7 @@ copyright_year   = 2014
 
 [@Basic]
 [PodSyntaxTests]
-[PodCoverageTests]
+;[PodCoverageTests]
 [Test::Perl::Critic]
 [AutoPrereqs]
 ; authordep Pod::Weaver::Section::Contributors
@@ -23,3 +23,9 @@ wrap_column = 74
 debug       = 0
 
 [GithubMeta]
+[Test::Kwalitee]
+[ReadmeAnyFromPod]
+[ReadmeAnyFromPod / ReadmePodInRoot]
+type = pod
+filename = README.pod
+location = root

--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_year   = 2014
 [VersionFromModule]
 
 [@Basic]
+[PodWeaver]
 [PodSyntaxTests]
 ;[PodCoverageTests]
 [Test::Perl::Critic]

--- a/dist.ini
+++ b/dist.ini
@@ -11,4 +11,15 @@ copyright_year   = 2014
 [PodCoverageTests]
 [Test::Perl::Critic]
 [AutoPrereqs]
+; authordep Pod::Weaver::Section::Contributors
 skip = Apache
+
+[TravisYML]
+[ChangelogFromGit]
+max_age     = 365
+tag_regexp  = ^v(\d+\.\d+)$
+file_name   = CHANGES
+wrap_column = 74
+debug       = 0
+
+[GithubMeta]


### PR DESCRIPTION
* Removed the markdown readme, replaced with autogenerated pod that renders correctly in github repo
* Added in travis config, will autogenerate
  * Committed version works but has exclusion because Archive::Zip has an issue
  * dzil builds will overwrite that, so be ready
  * You'll need to setup travis on your own repo to use, but you can see it in mine
* Started Pod::Weaver usage
  * makes documentation easier/cleaner
* Currently commented out Pod testing, because coverage is incomplete
  * short term, but allows us to test and prove what is working
* Test::Kwalitee to verify status before release
  * Already a higher score than it was before